### PR TITLE
Add exception whenever the karma-coverage can't find lcov configuration

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,8 @@ var CoverallsReporter = function(rootConfig, helper, logger) {
         filepath = path.resolve(rootConfig.basePath, reporter.dir);
         break;
       }
+    } else {
+     throw new Error("coverage reporter should precede coveralls");
     }
   }
 

--- a/test/tests.Spec.js
+++ b/test/tests.Spec.js
@@ -64,6 +64,40 @@ describe('Given the KarmaCoveralls Module', function () {
       .to.throw(Error, /coverage reporter should precede coveralls/);
   });
 
+  describe('when given the coverageReporter type/reporters parameter is not properly defined or undefined', function () {
+    beforeEach(function () {
+
+      mockConfig = {
+        reporters: ['coverage', 'coveralls']
+      };
+
+      helper = {
+        isDefined: function () {
+          return true;
+        }
+      };
+
+      logger = {
+        create: function () {
+          return {
+            debug: function () {
+            },
+            info: function () {
+            }
+          }
+        }
+      };
+    });
+
+
+    it('should log an error if it doesn\'t find LCOV configuration', function (done) {
+      expect(CoverallsReporter.bind(this, mockConfig, helper, logger))
+        .to.throw(Error, /LCOV configuration was not found. Maybe you missed something\?/);
+
+      done();
+    });
+  });
+
 
   describe('when given the right parameters', function () {
     beforeEach(function () {
@@ -104,7 +138,6 @@ describe('Given the KarmaCoveralls Module', function () {
       var rootConfig = createKarmaConfig(mockConfig);
       var result = new CoverallsReporter(mockConfig, helper, logger);
       result._onExit(function () {
-
         expect(coverallsMock.sendToCoveralls.called).to.be.true;
         done();
       });


### PR DESCRIPTION
Greetings! I used the plugin for the first-time today. (It helped me a lot!) But I struggled a bit at first glance to make it work, due to my `coverageReporter` wrong setup. The `karma-coverage` would not find the `lcov configuration` and still try to run all the operations without loggin it to the user. So I thought of tweaking it out.

Thou I'm not sure if the added test-case follow the guideline, If it is wrong please let me know and I will work on it.

Cheers!